### PR TITLE
Remove unncessary async code.

### DIFF
--- a/examples/loggers.rs
+++ b/examples/loggers.rs
@@ -1,7 +1,7 @@
 extern crate sids;
 use env_logger::{Builder, Env};
 use log::info;
-use sids::actors::actor::{ActorTrait, BlockingActorTrait};
+use sids::actors::actor::ActorTrait;
 use sids::actors::api::*;
 use sids::actors::messages::InternalMessage;
 
@@ -28,7 +28,7 @@ impl ActorTrait for SampleActor
 where
     SampleActor: 'static,
 {
-    async fn receive(&mut self, message: InternalMessage) {
+    fn receive(&mut self, message: InternalMessage) {
         let name = self.name.clone();
         // Log the message received by the actor.
         info!("Actor {} received message: {:?}", self.name, message);
@@ -44,21 +44,16 @@ impl ActorTrait for SampleBlockingActor
 where
     SampleBlockingActor: 'static,
 {
-    async fn receive(&mut self, message: InternalMessage) {
+    fn receive(&mut self, message: InternalMessage) {
         // do nothing
         info!("Received message in blocking actor via ActorTrait");
-        self.handle_message(message);
-    }
-}
-
-impl BlockingActorTrait for SampleBlockingActor {
-    fn handle_message(&mut self, _message: InternalMessage) {
-        info!("Received message to blocking actor");
-        if let InternalMessage::StringMessage { message } = _message {
+        if let InternalMessage::StringMessage { message } = message {
             info!("Blocking actor received string message: {}", message);
         }
     }
 }
+
+
 
 async fn start_sample_actor_system() {
     // Start an actor system and spawn a few officers with some actors that send messages to each other.

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -11,7 +11,7 @@ static SIDS_DEFAULT_BUFFER_SIZE: usize = 100;
 pub mod api {
     use log::info;
 
-    use super::{actor::BlockingActorTrait, messages::InternalMessage};
+    use super::messages::InternalMessage;
 
     use crate::actors::actor_system::ActorSystem;
 
@@ -34,7 +34,7 @@ pub mod api {
         actor_system
     }
 
-    pub async fn spawn_blocking_officer<T: BlockingActorTrait + 'static>(
+    pub async fn spawn_blocking_officer<T: ActorTrait + 'static>(
         actor_system: &mut ActorSystem,
         name: Option<String>, 
         actor_type: T,
@@ -122,7 +122,7 @@ pub mod api {
 
         struct Logging;
         impl ActorTrait for Logging {
-            async fn receive(&mut self, message: InternalMessage) {
+            fn receive(&mut self, message: InternalMessage) {
                 log::info!("Logging message: {:?}", message);
             }
 

--- a/src/actors/actor.rs
+++ b/src/actors/actor.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 
 struct Dummy;
 impl ActorTrait for Dummy {
-    async fn receive(&mut self, _message: InternalMessage) {
+    fn receive(&mut self, _message: InternalMessage) {
         // do nothing
     }
 }
@@ -18,24 +18,10 @@ pub (super) fn create_dummy_actor() -> ActorRef {
 }
 
 
-pub (super) async fn blocking_actor_receive( actor: &mut dyn BlockingActorTrait, message: InternalMessage) {
-    actor.handle_message(message);
-}
-
-
 /// The main actor trait that all actors must implement.
 #[trait_variant::make(Send)]
 pub trait ActorTrait{
-    async fn receive(&mut self, message: InternalMessage) where Self: Sized;
-}
-
-/// Used for actors that block on message receive.
-pub trait BlockingActorTrait: ActorTrait {
-    fn receive(&mut self, message: InternalMessage) -> impl std::future::Future<Output = ()> + Send where Self: Sized {async {
-        blocking_actor_receive(self, message).await;
-    } }
-
-    fn handle_message(&mut self, message: InternalMessage);
+    fn receive(&mut self, message: InternalMessage) where Self: Sized;
 }
 
 /// Helper function for running the guardian actor.
@@ -51,15 +37,15 @@ pub (super) async fn run_guardian(mut actor: Guardian) {
 pub (super) async fn run_an_actor<T: ActorTrait + 'static>(mut actor : Actor<T>) {
     while let Some(message) = actor.receiver.recv().await {
         info!("Running an actor");
-        actor.receive(message).await;
+        actor.receive(message);
     }
 
 }
 
 /// Helper function for running a blocking actor.
-pub (super) fn run_a_blocking_actor<T: BlockingActorTrait>(mut actor: BlockingActor<T>) {
+pub (super) fn run_a_blocking_actor<T: ActorTrait>(mut actor: BlockingActor<T>) {
     while let Ok(message) = actor.receiver.recv() {
-        actor.handle_message(message);
+        actor.receive(message);
     }
 }
 
@@ -71,9 +57,9 @@ pub (super) struct Actor<T> {
 }
 
 impl <T: ActorTrait> Actor<T> {
-    pub (super) async fn receive(&mut self, message: InternalMessage){
+    pub (super) fn receive(&mut self, message: InternalMessage){
         info!("Actor {} received message", self.name.clone().unwrap_or("Unnamed Actor".to_string()));
-        ActorTrait::receive(&mut self.actor, message).await;
+        ActorTrait::receive(&mut self.actor, message);
     }
     pub (super) fn new (name: Option<String>, actor: T, receiver: mpsc::Receiver::<InternalMessage>) -> Self {
 
@@ -87,14 +73,11 @@ pub (super) struct BlockingActor<T> {
     receiver: std::sync::mpsc::Receiver<InternalMessage>
 }
 
-impl <T: BlockingActorTrait> BlockingActor<T> {
+impl <T: ActorTrait> BlockingActor<T> {
     #[allow(dead_code)]
      pub (super) fn receive(&mut self, message: InternalMessage) {
         info!("Blocking actor {} received message", self.name.clone().unwrap_or("Unnamed Blocking Actor".to_string()));
-        BlockingActorTrait::handle_message(&mut self.actor, message);
-    }
-    pub (super) fn handle_message(&mut self, message: InternalMessage) {
-        BlockingActorTrait::handle_message(&mut self.actor, message);
+        ActorTrait::receive(&mut self.actor, message);
     }
 
     pub (super) fn new (name: Option<String>, actor: T, receiver: std::sync::mpsc::Receiver<InternalMessage>) -> BlockingActor<T> {

--- a/src/actors/actor_ref.rs
+++ b/src/actors/actor_ref.rs
@@ -1,6 +1,6 @@
 use crate::actors::actor::{run_a_blocking_actor, run_guardian};
 
-use super::actor::{ run_an_actor, Actor, ActorTrait, BlockingActor, BlockingActorTrait};
+use super::actor::{ run_an_actor, Actor, ActorTrait, BlockingActor};
 use super::guardian::Guardian;
 use super::messages::{InternalMessage, Message };
 use log::info;
@@ -49,7 +49,7 @@ pub struct BlockingActorRef {
 }
 
 impl BlockingActorRef{
-    pub (super) fn new<T: BlockingActorTrait + std::marker::Send +  'static>(actor : BlockingActor<T>, sender: std::sync::mpsc::Sender<InternalMessage>) -> Self {
+    pub (super) fn new<T: ActorTrait + std::marker::Send +  'static>(actor : BlockingActor<T>, sender: std::sync::mpsc::Sender<InternalMessage>) -> Self {
         info!(actor = "Blocking Actor"; "Spawning a Blocking Actor");
         std::thread::spawn(move | | {
             //
@@ -68,14 +68,14 @@ impl BlockingActorRef{
 mod tests {
 
     use super::*;
-    use crate::actors::actor::{blocking_actor_receive, ActorTrait, BlockingActorTrait};
+    use crate::actors::actor::ActorTrait;
     use super::super::messages::InternalMessage;
     use tokio::sync::mpsc;
 
     struct SampleActor;
         
     impl ActorTrait for SampleActor {
-        async fn receive(&mut self, _message: InternalMessage) {
+        fn receive(&mut self, _message: InternalMessage) {
             // do nothing
             info!("Received message");
         }
@@ -84,15 +84,9 @@ mod tests {
     struct SampleBlockingActor; 
 
     impl ActorTrait for SampleBlockingActor {
-        async fn receive(&mut self, message:InternalMessage) {
-            blocking_actor_receive(self, message).await;
-        }
-    }
-
-    impl BlockingActorTrait for SampleBlockingActor  {
-        
-        fn handle_message(&mut self, _message: InternalMessage) {
-            info!("Received message");
+        fn receive(&mut self, _message:InternalMessage) {
+            // do nothing
+            info!("Received message in blocking actor via ActorTrait");
         }
     }
 

--- a/src/actors/actor_system.rs
+++ b/src/actors/actor_system.rs
@@ -1,7 +1,7 @@
 
 use std::io::{Error, ErrorKind};
 
-use super::{actor::{Actor, ActorTrait, BlockingActor, BlockingActorTrait}, actor_ref::{ActorRef, BlockingActorRef, GuardianActorRef}, guardian::Guardian, messages::{ InternalMessage, Message, ResponseMessage}};
+use super::{actor::{Actor, ActorTrait, BlockingActor}, actor_ref::{ActorRef, BlockingActorRef, GuardianActorRef}, guardian::Guardian, messages::{ InternalMessage, Message, ResponseMessage}};
 use log::info;
 
 
@@ -79,7 +79,7 @@ impl ActorSystem {
         }
     }
 
-    pub (super) async fn create_blocking_officer<T: BlockingActorTrait + 'static>(&mut self, actor_type: T, name: Option<String>) -> Result<(), Error> {
+    pub (super) async fn create_blocking_officer<T: ActorTrait + 'static>(&mut self, actor_type: T, name: Option<String>) -> Result<(), Error> {
         info!("Creating blocking officer called {}", name.clone().unwrap_or("Unnamed".to_string()));
         let (tx2, rx2) = std::sync::mpsc::channel::<InternalMessage>();
         // create actor reference here and send it to the guardian.

--- a/src/actors/community/collector.rs
+++ b/src/actors/community/collector.rs
@@ -2,48 +2,47 @@ use std::io::{Error, Write};
 
 use log::info;
 
-use crate::actors::{actor::{ActorTrait, BlockingActorTrait}, messages::{InternalMessage, ResponseMessage}};
-
-
-
+use crate::actors::{
+    actor::ActorTrait,
+    messages::{InternalMessage, ResponseMessage},
+};
 
 // Generic blocking actor that will be used to collect data via an http call.
 pub struct Collector;
 
-impl ActorTrait for Collector where Collector: 'static {
-    async fn receive(&mut self, message: InternalMessage) {
+impl ActorTrait for Collector
+where
+    Collector: 'static,
+{
+    fn receive(&mut self, message: InternalMessage) {
         // do nothing
         info!("Received message in blocking actor via ActorTrait");
-        self.handle_message(message);
-
-    }
-}
-impl BlockingActorTrait for Collector {
-
-    fn handle_message(&mut self, message: InternalMessage) {
-        info!("Received message to blocking actor");
-        if let InternalMessage::GetUrl { url, output, responder  } = message {
-            info!("Blocking actor received string message to get url at: {}", url);
+        if let InternalMessage::GetUrl {
+            url,
+            output,
+            responder,
+        } = message
+        {
+            info!(
+                "Blocking actor received string message to get url at: {}",
+                url
+            );
             match self.get_uri(url, output) {
                 Ok(_) => {
                     info!("Successfully got the URI");
                     let _ = responder.send(ResponseMessage::Success);
-                },
+                }
                 Err(e) => {
                     info!("Failed to get the URI due to {:?}", e);
                     let _ = responder.send(ResponseMessage::Failure);
                 }
             }
-
         }
     }
-    
-    
-
 }
-    // Collector requires spawn blocking in order to get the response from the reqwest::blocking::get method.
- impl Collector {   
 
+// Collector requires spawn blocking in order to get the response from the reqwest::blocking::get method.
+impl Collector {
     fn get_uri(&self, uri: String, location: String) -> Result<(), Error> {
         if cfg!(test) {
             return Ok(());


### PR DESCRIPTION
All async definitions have been removed and confirmed that the examples still work.

This also meant that the BlockingActorTrait is not needed as well.