### PR TITLE
Change naming structure for developer experience. Message -> GuardianMessage, InternalMessage -> Message, ActorTrait -> Actor, Actor<T> -> ActorImpl<T>, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,23 @@ to notify a higher level actor (usually the guardian) about the result, often a 
 
 ```rust
 
-use sids::actors::actor::ActorTrait;
+use sids::actors::actor::Actor;
 
 
 // you can include some attributes like a name if you wish
 struct MyActor;
-impl ActorTrait for MyActor where MyActor: 'static {
+impl Actor for MyActor where MyActor: 'static {
     // in future this may not need to be async
-    async fn receive(&mut self, message: InternalMessage) {
+    async fn receive(&mut self, message: Message) {
+        // The `Message` enum carries all possible messages in the system.
+        // Customization may be available in the future, but for now, it is also possible
+        // to use the StringMessage variant to provide custom messages.
         match message {
-            InternalMessage::StringMessage { string } => 
+            Message::StringMessage { string } => 
+                // custom options here
+                // as in "if string == 'hello' => println("hello there friend");"
                 info!("Received message {}", string),
-            InternalMessage::RequestStatus { responder } {
+            Message::RequestStatus { responder } {
                 responder.send(ResponseMessage::Ok)
             }
         },
@@ -73,7 +78,7 @@ actor, you simple do:
 send_message_to_officer_enum(
     &actor_system, // the actor system
     0, // the officer id, currently a simple Vec index for now
-    InternalMessage::RequestStatus, // the message you wish to send
+    Message::RequestStatus, // the message you wish to send
     false // whether the actor is a thread-blocking type (see below)
     );
 

--- a/examples/collection.rs
+++ b/examples/collection.rs
@@ -3,7 +3,7 @@ extern crate sids;
 use env_logger::{Builder, Env};
 use log::info;
 use sids::actors::community::collector::Collector;
-use sids::actors::messages::InternalMessage;
+use sids::actors::messages::Message;
 
 // NOTE: This will collect some data from the internet and store it in the current directory.
 
@@ -31,9 +31,9 @@ async fn start_sample_actor_system() {
     let (tx3, rx3) = tokio::sync::oneshot::channel();
 
 
-    let message1 = InternalMessage::GetUrl { url: "https://www.rust-lang.org".to_string(), output: "./rust.html_sample".to_string(), responder: tx1 };
-    let message2 = InternalMessage::GetUrl { url: "https://www.google.com".to_string(), output: "./google.html_sample".to_string(), responder: tx2 };
-    let message3 = InternalMessage::GetUrl { url: "https://www.github.com".to_string(), output: "./github.html_sample".to_string(), responder: tx3 };
+    let message1 = Message::GetUrl { url: "https://www.rust-lang.org".to_string(), output: "./rust.html_sample".to_string(), responder: tx1 };
+    let message2 = Message::GetUrl { url: "https://www.google.com".to_string(), output: "./google.html_sample".to_string(), responder: tx2 };
+    let message3 = Message::GetUrl { url: "https://www.github.com".to_string(), output: "./github.html_sample".to_string(), responder: tx3 };
     sids::actors::api::send_message_to_officer_enum(&mut actor_system, 0, message1, true).await;
     sids::actors::api::send_message_to_officer_enum(&mut actor_system, 1, message2, true).await;
     sids::actors::api::send_message_to_officer_enum(&mut actor_system, 2, message3, true).await;

--- a/examples/loggers.rs
+++ b/examples/loggers.rs
@@ -1,9 +1,9 @@
 extern crate sids;
 use env_logger::{Builder, Env};
 use log::info;
-use sids::actors::actor::ActorTrait;
+use sids::actors::actor::Actor;
 use sids::actors::api::*;
-use sids::actors::messages::InternalMessage;
+use sids::actors::messages::Message;
 
 // Idea here is that using the logs, we can provide an animation of actors receiving messages and sending messages to each other.
 
@@ -24,15 +24,15 @@ impl SampleActor {
     }
 }
 
-impl ActorTrait for SampleActor
+impl Actor for SampleActor
 where
     SampleActor: 'static,
 {
-    fn receive(&mut self, message: InternalMessage) {
+    fn receive(&mut self, message: Message) {
         let name = self.name.clone();
         // Log the message received by the actor.
         info!("Actor {} received message: {:?}", self.name, message);
-        if let InternalMessage::StringMessage { message } = message {
+        if let Message::StringMessage { message } = message {
             info!("Actor {} received string message: {}", name, message);
         }
     }
@@ -40,14 +40,14 @@ where
 
 struct SampleBlockingActor;
 
-impl ActorTrait for SampleBlockingActor
+impl Actor for SampleBlockingActor
 where
     SampleBlockingActor: 'static,
 {
-    fn receive(&mut self, message: InternalMessage) {
+    fn receive(&mut self, message: Message) {
         // do nothing
-        info!("Received message in blocking actor via ActorTrait");
-        if let InternalMessage::StringMessage { message } = message {
+        info!("Received message in blocking actor via Actor trait");
+        if let Message::StringMessage { message } = message {
             info!("Blocking actor received string message: {}", message);
         }
     }
@@ -87,7 +87,7 @@ async fn start_sample_actor_system() {
         true,
     )
     .await;
-    send_message_to_officer_enum(&mut actor_system, 0, InternalMessage::Terminate, false).await;
+    send_message_to_officer_enum(&mut actor_system, 0, Message::Terminate, false).await;
 }
 
 #[tokio::main]

--- a/src/actors.rs
+++ b/src/actors.rs
@@ -11,17 +11,17 @@ static SIDS_DEFAULT_BUFFER_SIZE: usize = 100;
 pub mod api {
     use log::info;
 
-    use super::messages::InternalMessage;
+    use super::messages::Message;
 
     use crate::actors::actor_system::ActorSystem;
 
-    use super::actor::ActorTrait;
+    use super::actor::Actor;
 
     pub fn start_actor_system() -> ActorSystem {
         ActorSystem::new()
     }
 
-    pub async fn spawn_officer<T: ActorTrait + 'static>(
+    pub async fn spawn_officer<T: Actor + 'static>(
         actor_system: &mut ActorSystem,
         name: Option<String>, 
         actor_type: T,
@@ -34,7 +34,7 @@ pub mod api {
         actor_system
     }
 
-    pub async fn spawn_blocking_officer<T: ActorTrait + 'static>(
+    pub async fn spawn_blocking_officer<T: Actor + 'static>(
         actor_system: &mut ActorSystem,
         name: Option<String>, 
         actor_type: T,
@@ -46,7 +46,7 @@ pub mod api {
         actor_system
     }
 
-    pub async fn spawn_courrier<T: ActorTrait + 'static>(
+    pub async fn spawn_courrier<T: Actor + 'static>(
         actor_system: &mut ActorSystem,
         officer_id: u32,
         courrier_type: T,
@@ -94,7 +94,7 @@ pub mod api {
         message: String,
         blocking: bool
     ) -> &mut ActorSystem {
-        let message = InternalMessage::StringMessage { message};
+        let message = Message::StringMessage { message};
         actor_system
             .dispatch(officer_id, message, blocking)
             .await;
@@ -104,7 +104,7 @@ pub mod api {
     pub async fn send_message_to_officer_enum (
         actor_system: &mut ActorSystem,
         officer_id: u32,
-        message: InternalMessage,
+        message: Message,
         blocking: bool
     ) -> &mut ActorSystem {
         actor_system
@@ -116,13 +116,13 @@ pub mod api {
     #[cfg(test)]
     mod tests {
 
-        use crate::actors::{actor::ActorTrait, messages::InternalMessage};
+        use crate::actors::{actor::Actor, messages::Message};
 
         use super::*;
 
         struct Logging;
-        impl ActorTrait for Logging {
-            fn receive(&mut self, message: InternalMessage) {
+        impl Actor for Logging {
+            fn receive(&mut self, message: Message) {
                 log::info!("Logging message: {:?}", message);
             }
 

--- a/src/actors/community/collector.rs
+++ b/src/actors/community/collector.rs
@@ -3,21 +3,21 @@ use std::io::{Error, Write};
 use log::info;
 
 use crate::actors::{
-    actor::ActorTrait,
-    messages::{InternalMessage, ResponseMessage},
+    actor::Actor,
+    messages::{Message, ResponseMessage},
 };
 
 // Generic blocking actor that will be used to collect data via an http call.
 pub struct Collector;
 
-impl ActorTrait for Collector
+impl Actor for Collector
 where
     Collector: 'static,
 {
-    fn receive(&mut self, message: InternalMessage) {
+    fn receive(&mut self, message: Message) {
         // do nothing
         info!("Received message in blocking actor via ActorTrait");
-        if let InternalMessage::GetUrl {
+        if let Message::GetUrl {
             url,
             output,
             responder,

--- a/src/actors/messages.rs
+++ b/src/actors/messages.rs
@@ -8,11 +8,11 @@ use super::actor_ref::{ActorRef, BlockingActorRef};
 /// The guardian actor will create the responders to allow for the officers to communicate back to the guardian
 /// for status updates and other messages.
 #[derive(Debug)]
-pub (super) enum Message {
+pub (super) enum GuardianMessage {
     Terminate,
     OfficerMessage {
         officer_id: u32,
-        message: InternalMessage,
+        message: Message,
         blocking: bool,
     },
     CreateOfficer {
@@ -41,7 +41,7 @@ pub (super) enum Message {
     },
     NotifyCourriers {
         officer_id: u32,
-        message: InternalMessage,
+        message: Message,
         responder: tokio::sync::oneshot::Sender<ResponseMessage>,
         blocking: bool,
     },
@@ -53,7 +53,7 @@ pub (super) enum Message {
 ///
 /// All responders created by these items ought to be created by the guardian actor.
 #[derive(Debug)]
-pub enum InternalMessage {
+pub enum Message {
     StringMessage {
         message: String,
     },

--- a/src/actors/officer.rs
+++ b/src/actors/officer.rs
@@ -1,8 +1,7 @@
 use log::info;
 
 use super::actor_ref::{ActorRef, BlockingActorRef};
-use super::messages::InternalMessage;
-use super::messages;
+use super::messages::Message;
 
 
 
@@ -28,7 +27,7 @@ impl Officer {
         }
     }
 
-    pub async fn send(&mut self, message: messages::InternalMessage) {
+    pub async fn send(&mut self, message: Message) {
         info!(actor="officer"; "Sending message to officer {}.", self._id);
         self.actor.send(message).await;
     }
@@ -45,7 +44,7 @@ impl Officer {
 
 
     /// Send a message to all courriers.
-    pub async fn notify(&mut self, _message: &InternalMessage) -> Result<(), std::io::Error> {
+    pub fn notify(&mut self, _message: &Message) -> Result<(), std::io::Error> {
         for _courier in self.courriers.iter_mut() {
             // Need to provide some abstraction for courriers to receive an update broadcast.
         }
@@ -66,13 +65,13 @@ impl BlockingOfficer {
         }
     }
 
-    pub fn send(&mut self, message: messages::InternalMessage) {
+    pub fn send(&mut self, message: Message) {
         info!(actor="BlockingOfficer"; "Sending message to BlockingOfficer");
         self.actor.send(message);
     }
 
-    pub async fn notify(&mut self, message: &InternalMessage) -> Result<(), std::io::Error> {
-        let _ = self.officer.notify(message).await;
+    pub fn notify(&mut self, message: &Message) -> Result<(), std::io::Error> {
+        let _ = self.officer.notify(message);
         Ok(())
     }
 


### PR DESCRIPTION
Changed the naming structure to focus more on logical language for developer who might use the repo.